### PR TITLE
filter_mode: change default from `added` to `file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ github-pr-review can use Markdown and add a link to rule page in reviewdog repor
 ### `filter_mode`
 
 Optional. Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
-Default is added.
+Default is `file`.
 
 ### `fail_on_error`
 

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
   filter_mode:
     description: |
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
-      Default is added.
-    default: 'added'
+      Default is `file`.
+    default: 'file'
     required: false
   fail_on_error:
     description: |


### PR DESCRIPTION
Hi, I was hit hard by the default setting `filder_mode: added`: a developer of ours removed a line, the producion broke but the Github Action passed.

I propose here to have `file` as the default method: it's equally fast and doesn't miss such critical cases.
