### PR TITLE
Exit successfully if no files have been found

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -15,6 +15,12 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 FILES=$(find "${INPUT_PATH:-'.'}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN:-'*.sh'}")
 
+# Exit early if no files have been found
+if [ -z "${FILES}" ]; then
+  echo "No matching files found to check."
+  exit 0
+fi
+
 echo '::group:: Running shellcheck ...'
 if [ "${INPUT_REPORTER}" = 'github-pr-review' ]; then
   # erroformat: https://git.io/JeGMU


### PR DESCRIPTION
Currently, if a repository has no ".sh" files, this action will throw an error:
![image](https://user-images.githubusercontent.com/2787581/141349165-84f52ccc-3cab-4719-bed1-9da4bb3519d8.png)

This small snippet should fix the problem and print a message to the user.