### PR TITLE
Be more strict about matching shebangs in files

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -29,3 +29,17 @@ jobs:
           pattern: '*.sh'
           path: '.'
           exclude: './testdata/*'
+      - name: shellcheck-shebang-check
+        uses: ./
+        with:
+          github_token: ${{ secrets.github_token }}
+          filter_mode: nofilter
+          pattern: |
+            *.sh
+          path: |
+            .
+            ./testdata
+          exclude: |
+            ./testdata/test.sh
+            */.git/*
+          check_all_files_with_shebangs: true

--- a/script.sh
+++ b/script.sh
@@ -37,10 +37,10 @@ done <<< "${INPUT_EXCLUDE:-}"
 # Match all files matching the pattern
 files_with_pattern=$(find "${paths[@]}" "${excludes[@]}" -type f "${names[@]}")
 
-# Match all files with a shebang (e.g. "#!/usr/bin/env zsh" or even "#!/my/path/bash") in the first two lines
+# Match all files with a shebang (e.g. "#!/usr/bin/env zsh" or even "#!/my/path/bash") in the first line of a file
 # Ignore files which match "$pattern" in order to avoid duplicates
 if [ "${INPUT_CHECK_ALL_FILES_WITH_SHEBANGS}" = "true" ]; then
-  files_with_shebang=$(find "${paths[@]}" "${excludes[@]}" -not "${names[@]}" -type f -print0 | xargs -0 grep -m2 -IrlZ "^#\\!/.*sh" | xargs -r -0 echo)
+  files_with_shebang=$(find "${paths[@]}" "${excludes[@]}" -not "${names[@]}" -type f -print0 | xargs -0 awk 'FNR==1 && /#!\/.*sh/ { print FILENAME }')
 fi
 
 # Exit early if no files have been found

--- a/script.sh
+++ b/script.sh
@@ -37,10 +37,10 @@ done <<< "${INPUT_EXCLUDE:-}"
 # Match all files matching the pattern
 files_with_pattern=$(find "${paths[@]}" "${excludes[@]}" -type f "${names[@]}")
 
-# Match all files with a shebang (e.g. "#!/usr/bin/env zsh" or even "#!/my/path/bash") in the first line of a file
+# Match all files with a shebang (e.g. "#!/usr/bin/env zsh" or even "#!bash") in the first line of a file
 # Ignore files which match "$pattern" in order to avoid duplicates
 if [ "${INPUT_CHECK_ALL_FILES_WITH_SHEBANGS}" = "true" ]; then
-  files_with_shebang=$(find "${paths[@]}" "${excludes[@]}" -not "${names[@]}" -type f -print0 | xargs -0 awk 'FNR==1 && /#!\/.*sh/ { print FILENAME }')
+  files_with_shebang=$(find "${paths[@]}" "${excludes[@]}" -not "${names[@]}" -type f -print0 | xargs -0 awk 'FNR==1 && /^#!.*sh/ { print FILENAME }')
 fi
 
 # Exit early if no files have been found

--- a/testdata/non-sh-test
+++ b/testdata/non-sh-test
@@ -1,0 +1,4 @@
+#!/usr/bin/env ksh
+# shellcheck enable=all
+
+echo "${1}"


### PR DESCRIPTION
Require a valid shebang in the first line of a file to be validated by
shellcheck.

This allows embedding shell snippets in e.g. markdown files.