### PR TITLE
chore(deps): update koalaman/shellcheck to 0.10.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:
-        SHELLCHECK_VERSION: 0.9.0
+        SHELLCHECK_VERSION: 0.10.0
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
The dedup workflow was disabled as there was no activity in this repo for a long time. Adding a manual PR until dedup runs again.