### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,15 @@ github-pr-review can use Markdown and add a link to rule page in reviewdog repor
 Optional. Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
 Default is `file`.
 
+### `fail_level`
+
+Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 ### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 Optional.  Exit code for reviewdog when errors are found [true,false]
 Default is `false`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Default is `file`.
 
 ### `fail_level`
 
-Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Optional. If set to `none`, always use exit code 0 for reviewdog.
+Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
 Possible values: [`none`, `any`, `info`, `warning`, `error`]
 Default is `none`.
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,8 @@ inputs:
     required: false
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,18 @@ inputs:
       Default is `file`.
     default: 'file'
     required: false
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
     required: false
   reviewdog_flags:
@@ -71,6 +79,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_PATH: ${{ inputs.path }}

--- a/script.sh
+++ b/script.sh
@@ -75,6 +75,7 @@ if [ "${INPUT_REPORTER}" = 'github-pr-review' ]; then
         -name="shellcheck" \
         -reporter=github-pr-review \
         -filter-mode="${INPUT_FILTER_MODE}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         -level="${INPUT_LEVEL}" \
         ${INPUT_REVIEWDOG_FLAGS}
@@ -88,6 +89,7 @@ else
         -name="shellcheck" \
         -reporter="${INPUT_REPORTER:-github-pr-check}" \
         -filter-mode="${INPUT_FILTER_MODE}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         -level="${INPUT_LEVEL}" \
         ${INPUT_REVIEWDOG_FLAGS}
@@ -105,6 +107,7 @@ shellcheck -f diff ${FILES} \
       -f.diff.strip=1 \
       -reporter="github-pr-review" \
       -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-level="${INPUT_FAIL_LEVEL}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       ${INPUT_REVIEWDOG_FLAGS}
 EXIT_CODE_SUGGESTION=$?


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply this to `action-shellcheck`.